### PR TITLE
Rdiscount

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,4 @@ version_url: https://github.com/mapbox/vector-tile-spec/tree/master/
 current: 2.1
 permalink: /:categories/:title
 baseurl: /vector-tiles
+markdown: rdiscount

--- a/_posts/spec/0001-02-01-notincluded.md
+++ b/_posts/spec/0001-02-01-notincluded.md
@@ -157,3 +157,4 @@ function rotateFlips(prefix) {
     flipStep = 1;
   }
 }
+</script>


### PR DESCRIPTION
Fixes #2, flagged by @ajashton 

* Had to close a `<script>` tag in one of the spec pages after changing markdown.
* rebased off of a fresh `mb-pages` since we were making some changes there earlier