### PR TITLE
Fix awesome-vt link

### DIFF
--- a/_posts/spec/0001-01-10-implementations.md
+++ b/_posts/spec/0001-01-10-implementations.md
@@ -13,4 +13,4 @@ Implementations of the Mapbox Vector Tile Specification are far and wide. Many o
 * Applications: browser-based tools for creating and visualizing vector tiles
 * Servers: support rendering and serving up vector tiles (*note: the specification doesn't go into how to do this explicitly*)
 
-A great list of tools implementing Mapbox Vector Tiles can be found at [github.com/mapbox/awesome-vector-tiles]({{site.spec_url}}).
+A great list of tools implementing Mapbox Vector Tiles can be found at [github.com/mapbox/awesome-vector-tiles](https://github.com/mapbox/awesome-vector-tiles/).


### PR DESCRIPTION
Clicking this link:
![](https://cldup.com/daYdCXvPjZ-3000x3000.png)

Takes you to https://github.com/mapbox/vector-tile-spec/.

This PR makes the link take you to https://github.com/mapbox/awesome-vector-tiles/, which I think was the original intent.

cc @mapsam 