### PR TITLE
updates to the encoding attributes section

### DIFF
--- a/_posts/spec/0001-01-06-encoding-attributes.md
+++ b/_posts/spec/0001-01-06-encoding-attributes.md
@@ -25,7 +25,7 @@ Take a look at the original geojson `FeatureCollection` on the left and see how 
   "properties": {
     <span class='attr gj' data-attr='1' data-key='hello' data-value='world'>"hello": "world",</span>
     <span class='attr gj' data-attr='2' data-key='h' data-value='world'>"h": "world",</span>
-    <span class='attr gj' data-attr='3' data-key='count' data-value='1.23'>"count": 1.23</span>
+    <span class='attr gj' data-attr='3' data-key='count' data-value='123'>"count": 1.23</span>
   }
 },</span>
     <span class='feature' data-feat='2'>{
@@ -65,13 +65,13 @@ Take a look at the original geojson `FeatureCollection` on the left and see how 
   type: Point
   geometry: ...
 }</span>
-  <span class='key' id='key-hello'>keys: "hello"</span>
+<span class='key-group'>  <span class='key' id='key-hello'>keys: "hello"</span>
   <span class='key' id='key-h'>keys: "h"</span>
-  <span class='key' id='key-count'>keys: "count"</span>
-  <span class='value' id='value-world'>values: {
+  <span class='key' id='key-count'>keys: "count"</span></span>
+<span class='value-group'>  <span class='value' id='value-world'>values: {
   string_value: "world"
 }</span>
-  <span class='value' id='value-1.23'>values: {
+  <span class='value' id='value-123'>values: {
   double_value: 1.23
 }</span>
   <span class='value' id='value-again'>values: {
@@ -79,7 +79,7 @@ Take a look at the original geojson `FeatureCollection` on the left and see how 
 }</span>
   <span class='value' id='value-2'>values: {
   int_value: 2
-}</span>
+}</span></span>
   extent: 4096
 }</div>
       </div>
@@ -102,12 +102,12 @@ function featureLeave(e) {
 $('.attr').on('mouseenter', attrEnter);
 $('.attr').on('mouseleave', attrLeave);
 function attrEnter(e) {
-  console.log($(this).attr('data-attr'));
   $('#attr'+$(this).attr('data-attr')).addClass('highlight');
   $('#key-'+$(this).attr('data-key')).addClass('highlight');
   $('#value-'+$(this).attr('data-value')).addClass('highlight');
+  $('.key-group, .value-group').addClass('highlight');
 }
 function attrLeave(e) {
-  $('.tagset, .key, .value').removeClass('highlight');
+  $('.tagset, .key, .value, .key-group, .value-group').removeClass('highlight');
 }
 </script>

--- a/css/site.css
+++ b/css/site.css
@@ -146,12 +146,52 @@ Attribute encoding example
 .tagset.highlight {
   background: #ffc28d;
 }
+.key-group,
+.value-group {
+  display: inline-block;
+  border-left: 2px solid #ffffff;
+  padding-left: 5px;
+  margin-left: -5px;
+  counter-reset: section -1;
+}
+.key-group.highlight {
+  border-left: 2px solid #f9a0e5;
+}
+.value-group.highlight {
+  border-left: 2px solid #b1d6c5;
+}
+.key,
+.value {
+  position: relative;
+}
+.key:before {
+  color: #f9a0e5;
+}
+.value:before {
+  color: #b1d6c5;
+}
+.key:before,
+.value:before {
+  opacity: 0.3;
+  position: absolute;
+  left: -10px;
+  top: 0px;
+  font-size: 9px;
+  font-weight: 900;
+  counter-increment: section;
+  content: counter(section);
+}
+.key.highlight:before,
+.value.highlight:before {
+  opacity: 1;
+}
 .key.highlight {
   background: #f9a0e5;
 }
 .value.highlight {
   background: #b1d6c5;
 }
+
 .feature:hover,
 .feat.highlight {
   background: #ccffe2;


### PR DESCRIPTION
* #8: adds an extra visual highlight as well as counters to help the user see how `tags` are counted.
* #7: removes the `.` from the `value-1.23` id since that's not allowed in HTML/CSS

<img width="585" alt="screen shot 2016-04-27 at 4 19 26 pm" src="https://cloud.githubusercontent.com/assets/1943001/14871407/a0f83196-0c96-11e6-8a1e-38d7e3792201.png">
