### PR TITLE
Fix syntax error in Streets source reference

### DIFF
--- a/_posts/services/0001-02-18-mapbox-streets-v7.md
+++ b/_posts/services/0001-02-18-mapbox-streets-v7.md
@@ -1013,7 +1013,7 @@ The __`maki`__ field lets you assign different icons to different types of airpo
 <tr><th>Value</th><th>Description</th></tr>
 <tr><td><code>'airport'</code></td><td>Most commercial airports</td></tr>
 <tr><td><code>'airfield'</code></td><td>Smaller airports & private airfields</td></tr>
-<tr><td><code>'heliport'</code></td><td></td>For helicopters</tr>
+<tr><td><code>'heliport'</code></td><td>For helicopters</td></tr>
 <tr><td><code>'rocket'</code></td><td>Spaceflight facilities</td></tr>
 </table>
 


### PR DESCRIPTION
The text “For helicopters” was outside a `<td>` tag, so it popped up to the top of the table:

<img width="738" alt="for-helicopters" src="https://cloud.githubusercontent.com/assets/1231218/15460283/f9cae44a-2063-11e6-80de-b37dd0d9cf71.png">

/cc @nickidlugash