### PR TITLE
Winding order fixes

### DIFF
--- a/_posts/spec/0001-01-05-encoding-geometry.md
+++ b/_posts/spec/0001-01-05-encoding-geometry.md
@@ -16,7 +16,7 @@ This is a step-by-step example showing how a single vector tile encodes geometry
       <button id="vt-next" class="button fill-green rcon next fr">Next step</button>
       <h4 id="vt-title">Step 0</h4>
       <p id="vt-command">An empty vector tile</p>
-      <p id="vt-description">The vector tile to the left is a 10x10 grid with 2 cell buffer. Let's encode some geometry to the grid. Let's start with the <span class="poly blue">blue polygon</span>.</p>
+      <p id="vt-description">The vector tile to the right is a 10x10 grid with 2 cell buffer. Let's encode some geometry to the grid. Let's start with the <span class="poly blue">blue polygon</span>.</p>
     </div>
     <div id="visuals" class="col3">
       <h4>Vector Tile Grid</h4>

--- a/_posts/spec/0001-01-08-winding-order.md
+++ b/_posts/spec/0001-01-08-winding-order.md
@@ -8,11 +8,13 @@ category: specification
 
 Winding order refers to the direction a ring is drawn in a vector tile, either clockwise or counter-clockwise. Many geometries are multipolygons with "holes," which are also represented as polygon rings. It is important to be able to infer winding order to extract source data from a vector tile and understand if the geometry is part of a multipolygon or a unique polygon.
 
-Extracting the original data from images has been difficult on maps in the past, because of the loss of underlying metadata from the geometry that might have been used to create the image. However, with the introduction of client side rendering of vector tiles via GL technologies, the raw geometry data has become useful suddenly for a source of information outside of just rendering.
+Extracting the original data from images has been difficult on maps in the past, because of the loss of underlying metadata from the geometry that might have been used to create the image. However, with the introduction of client side rendering of vector tiles via GL technologies, the raw geometry data has become useful for a source of information outside of just rendering.
 
 In order for renderers to appropriately distinguish which polygons are holes and which are unique geometries, the specification requires all polygons to be valid ([OGC validity](http://www.opengeospatial.org/standards/sfa)). Any polygon interior ring must be oriented with the winding order opposite that of their parent exterior ring and all interior rings must directly follow the exterior ring to which they belong. Exterior rings must be oriented clockwise and interior rings must be oriented counter-clockwise (when viewed in screen coordinates).
 
 The following example geometries show how encoding a ring's winding order can affect the rendered result. Each example assumes all rings are part of the same multipolygon.
+
+*Note: the `Y` axis is positive-downward in vector tile coordinates!*
 
 <div id="js-example-encoding" class="js-example clearfix">
   <div class="js-example-body">
@@ -27,7 +29,8 @@ The following example geometries show how encoding a ring's winding order can af
         <pre><code>Ring 1: Clockwise</code></pre>
       </div>
       <div class="col3 pad1 rotating-rings">
-        <img src="{{site.baseurl}}/images/cw.png" class="ring outer cw">
+        <div id="winding-order-axis"><div class="axis" id="x-axis"></div><div class="axis" id="y-axis"></div></div>
+        <img src="{{site.baseurl}}/images/cw.png" class="ring outer cw" id="axis-bump">
       </div>
       <div class="col3 pad1">
         <img src="{{site.baseurl}}/images/wo-1.png" class="render">
@@ -59,7 +62,7 @@ Ring 2: Counter-Clockwise</code></pre></div>
         <img src="{{site.baseurl}}/images/wo-3.png" class="render">
       </div>
     </div>
-    <div class="wo-block col12 clearfix">
+    <!-- <div class="wo-block col12 clearfix">
       <div class="col6 pad1">
         <p>Partially overlapping rings in a multipolygon with different winding orders. The second, counter-clockwise ring will be filled outside of the polygon, but not within. This is a result of <strong>even-odd filling</strong> style.</p>
         <pre><code>Ring 1: Clockwise
@@ -72,7 +75,7 @@ Ring 2: Counter-Clockwise</code></pre>
       <div class="col3 pad1">
         <img src="{{site.baseurl}}/images/wo-4.png" class="render">
       </div>
-    </div>
+    </div> -->
     <div class="wo-block col12 clearfix">
       <div class="col6 pad1">
         <p>Three rings in a multipolygon that alternate winding order.</p>

--- a/css/site.css
+++ b/css/site.css
@@ -330,6 +330,85 @@ Winding order example
     transform: rotate(0deg);
   }
 }
+/*#winding-order-axis {
+  position: relative;
+}*/
+.axis {
+  background: #c0c0c0;
+  color: #c0c0c0;
+}
+#axis-bump {
+  margin-top: -47px;
+}
+#x-axis {
+  width: 100px;
+  height: 1px;
+}
+#y-axis {
+  height: 100px;
+  width: 1px;
+}
+#y-axis:before,
+#x-axis:before {
+  background: white;
+  color: #c0c0c0;
+  font-weight: 900;
+  position: absolute;
+  width: 10px;
+  height: 15px;
+  font-size: 10px;
+}
+#y-axis:before {
+  content: "y";
+  vertical-align: middle;
+  top: 45%;
+  left: 7px;
+  line-height: 11px;
+}
+#x-axis:before {
+  content: "x";
+  left: 45%;
+  text-align: center;
+  line-height: 0;
+}
+#y-axis:after,
+#x-axis:after {
+  position: absolute;
+  border-color: #c0c0c0;
+}
+#y-axis:after {
+  content: "";
+  top: 110px;
+  border-top: 5px solid #c0c0c0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  left: 7px;
+}
+#x-axis:after {
+  content: "";
+  left: 110px;
+  top: 7px;
+  border-left: 5px solid #c0c0c0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+}
+@media only screen and (min-width: 1200px) {
+  #axis-bump {
+    margin-top: -89px
+  }
+  #x-axis {
+    width: 200px;
+  }
+  #y-axis {
+    height: 200px;
+  }
+  #y-axis:after {
+    top: 210px;
+  }
+  #x-axis:after {
+    left: 210px;
+  }
+}
 
 
 


### PR DESCRIPTION
* Fixes minor copy mistake: #16 
* Adds a x & y axis to the winding order examples for clarification of positive-down y-axis. #18 
* Removes the OGC invalid winding order example #19 

<img width="997" alt="screen shot 2016-08-08 at 8 14 41 am" src="https://cloud.githubusercontent.com/assets/1943001/17480971/30b539b0-5d40-11e6-8ac5-cc952cca66bf.png">


cc @nvkelso