### PR TITLE
Fix motorway_junction anchor

### DIFF
--- a/_posts/services/0001-02-18-mapbox-streets-v7.md
+++ b/_posts/services/0001-02-18-mapbox-streets-v7.md
@@ -946,7 +946,7 @@ The __`len`__ field stores the length of the road segment in projected meters, r
 
 
 <!-- MOTORWAY_JUNCTION_LABEL -->
-<a class='doc-section' id='motorway_junction_label'></a>
+<a class='doc-section' id='motorway_junction'></a>
 <h3><a href='#motorway_junction'>#motorway_junction</a>
     <div class='geomtype' title='lines'>
         <span class='      inline small icon marker'></span>


### PR DESCRIPTION
The `#motorway_junction` heading was linking to a `#motorway_junction` anchor, but instead there was a `#motorway_junction_label` anchor, which I think was a typo.

/cc @ajashton