### PR TITLE
Remove broken image link and update wording for streets-v7

### DIFF
--- a/_posts/services/0001-02-18-mapbox-streets-v7.md
+++ b/_posts/services/0001-02-18-mapbox-streets-v7.md
@@ -101,11 +101,7 @@ A geometry in the vector tile can be one of 3 types:
 2. <span class='small inline icon polyline'></span> Linestring / multilinestring
 3. <span class='small inline icon polygon'></span> Polygon / multipolygon
 
-
-In Mapbox Studio, you can select just one or two or all of the 3 types with the Geometry Type toggles:
-
-<img class='pady4' src='/img/developers/vector-tiles/filter-geomtype.png'>
-
+In Mapbox Studio, you can select one, two, or all three of these geometry types with the Geometry Type toggles in each layer's **Select data** tab.
 
 <h3>Data updates</h3>
 


### PR DESCRIPTION
Per https://github.com/mapbox/vector-tiles/issues/60, there was a broken image link in the [Mapbox Streets v7 docs](https://www.mapbox.com/vector-tiles/mapbox-streets-v7/#overview). This PR removes the broken image link and updates the wording so that it's in line with what's used in the v8 docs. (Not replacing the image because: the fewer UI screenshots there are in the world, the fewer UI screenshots need to be updated when the UI changes!)

@1ec5 for review please! 🙏 