### PR TITLE
Prepare for Streets v8 moving out of beta 🎉

### DIFF
--- a/_posts/services/0001-02-01-mapbox-streets.md
+++ b/_posts/services/0001-02-01-mapbox-streets.md
@@ -3,6 +3,6 @@ layout: redirect
 title: Mapbox Streets
 category: services
 permalink: /mapbox-streets/
-redirect: /mapbox-streets-v7/
+redirect: /mapbox-streets-v8/
 hidden: true
 ---

--- a/_posts/services/0001-02-17-mapbox-streets-v8.md
+++ b/_posts/services/0001-02-17-mapbox-streets-v8.md
@@ -54,9 +54,7 @@ head: |
 <strong>mapbox.mapbox-streets-v8</strong>
 </pre>
 
-<div class='note'><strong>Note:</strong> Mapbox Streets v8 is currently a beta release. The data structure is stable as documented, but there are still known issues and limited style examples.</div>
-
-This is an in-depth guide to the data inside the Mapbox Streets vector tile source to help with styling. <!--For full examples of using Mapbox Streets vector tiles to create a map style, check out the default templates in [Mapbox Studio](/studio).-->
+This is an in-depth guide to the data inside the Mapbox Streets vector tile source to help with styling. For full examples of using Mapbox Streets vector tiles to create a map style, check out the default styles in [Mapbox Studio](/studio).
 
 ## Overview
 

--- a/_posts/services/0001-02-18-mapbox-streets-v7.md
+++ b/_posts/services/0001-02-18-mapbox-streets-v7.md
@@ -50,8 +50,7 @@ is should be in single quotes as if you are using it in JSON, eg:
 <strong>mapbox.mapbox-streets-v7</strong>
 </pre>
 
-This is an in-depth guide to the data inside the Mapbox Streets vector tile source to help with styling. For full examples of using Mapbox Streets vector tiles to create a map style, check out the default templates in [Mapbox Studio](/studio).
-
+This is an in-depth guide to the data inside the Mapbox Streets vector tile source to help with styling.
 
 ## Overview
 


### PR DESCRIPTION
Removes beta note from Mapbox Streets v8 docs and updates `/vector-tiles/mapbox-streets` redirect to point to the v8 docs. 

cc @brsbl @agentpu1011 