### PR TITLE
correct building zoom

### DIFF
--- a/src/pages/reference/mapbox-streets-v7.md
+++ b/src/pages/reference/mapbox-streets-v7.md
@@ -207,7 +207,7 @@ Cliff data from OpenStreetMap is designed such that the left-hand side of the li
 
 {{ <LayerInfo type={["polygon"]} buffer={2} /> }}
 
-Large buildings appear at zoom level 13, and all buildings are included in zoom level 14 and up.
+Large buildings appear at zoom level 13, and all buildings are included in zoom level 15 and up.
 
 #### Underground buildings
 

--- a/src/pages/reference/mapbox-streets-v8.md
+++ b/src/pages/reference/mapbox-streets-v8.md
@@ -427,7 +427,7 @@ The `maki` field lets you assign different icons to different types of airports.
 
 {{ <LayerInfo type={["polygon"]} buffer={2} /> }}
 
-Large buildings appear at zoom level 13, and all buildings are included in zoom level 14 and up.
+Large buildings appear at zoom level 13, and all buildings are included in zoom level 15 and up.
 
 #### <!--building--> `underground` _text_
 


### PR DESCRIPTION
For both mapbox-streets-v7 and mapbox-streets-v8 complete building coverage only starts at zoom 15. This change corrects the documentation to match what is actually implemented.